### PR TITLE
Changed Host header in the outgoing request to  avoid blocking

### DIFF
--- a/main/proxy.go
+++ b/main/proxy.go
@@ -71,6 +71,7 @@ func appProxy(target *url.URL) *httputil.ReverseProxy {
 		log.Println(string(requestDump))
 		log.Println("------------------------End of Request-------------")
 		targetUrl, _ := getTargetHost(req)
+		req.Host = targetUrl.Host // changing Host header to avoid blocking
 		req.URL.Scheme = targetUrl.Scheme
 		req.URL.Host = targetUrl.Host //config.Service["app"].ServiceEndpoint
 		req.URL.Path = req.URL.Path


### PR DESCRIPTION
- some sites block host header with different source, hence changing host header to avoid blocking.